### PR TITLE
MAG-13: Overwrite template

### DIFF
--- a/app/code/Diana/FirstModule/view/frontend/layout/default.xml
+++ b/app/code/Diana/FirstModule/view/frontend/layout/default.xml
@@ -10,5 +10,6 @@
         <referenceContainer name="content">
             <block name="first.block.via.module.default" template="Diana_FirstModule::first-template-via-module-default.phtml" />
         </referenceContainer>
+        <referenceBlock name="top.search" template="Diana_FirstModule::magento-search/search/form.mini-override.phtml" />
     </body>
 </page>

--- a/app/code/Diana/FirstModule/view/frontend/templates/magento-search/search/form.mini-override.phtml
+++ b/app/code/Diana/FirstModule/view/frontend/templates/magento-search/search/form.mini-override.phtml
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+?>
+<?php
+/** @var $block \Magento\Framework\View\Element\Template */
+/** @var $helper \Magento\Search\Helper\Data */
+/** @var $configProvider \Magento\Search\ViewModel\ConfigProvider */
+$helper = $this->helper(\Magento\Search\Helper\Data::class);
+$configProvider = $block->getData('configProvider');
+?>
+<div class="block block-search">
+    <div class="block block-title"><strong><?= $block->escapeHtml(__('Search')) ?></strong></div>
+    <div class="block block-content">
+        <form class="form minisearch" id="search_mini_form"
+              action="<?= $block->escapeUrl($helper->getResultUrl()) ?>" method="get">
+            <div class="field search">
+                <label class="label" for="search" data-role="minisearch-label">
+                    <span><?= $block->escapeHtml(__('Search')) ?></span>
+                </label>
+                <div class="control">
+                    <input id="search"
+                        <?php if ($configProvider->isSuggestionsAllowed()):?>
+                            data-mage-init='{"quickSearch":{
+                                    "formSelector":"#search_mini_form",
+                                    "url":"<?= $block->escapeUrl($helper->getSuggestUrl())?>",
+                                    "destinationSelector":"#search_autocomplete",
+                                    "minSearchLength":"<?= $block->escapeHtml($helper->getMinQueryLength()) ?>"}
+                               }'
+                        <?php endif;?>
+                           type="text"
+                           name="<?= $block->escapeHtmlAttr($helper->getQueryParamName()) ?>"
+                           value="<?= /* @noEscape */ $helper->getEscapedQueryText() ?>"
+                           placeholder="<?= $block->escapeHtmlAttr(__('Search entire super-store here...')) ?>"
+                           class="input-text"
+                           maxlength="<?= $block->escapeHtmlAttr($helper->getMaxQueryLength()) ?>"
+                           role="combobox"
+                           aria-haspopup="false"
+                           aria-autocomplete="both"
+                           autocomplete="off"
+                           aria-expanded="false"/>
+                    <div id="search_autocomplete" class="search-autocomplete"></div>
+                    <?= $block->getChildHtml() ?>
+                </div>
+            </div>
+            <div class="actions">
+                <button type="submit"
+                        title="<?= $block->escapeHtmlAttr(__('Search')) ?>"
+                        class="action search"
+                        aria-label="Search"
+                >
+                    <span><?= $block->escapeHtml(__('Search')) ?></span>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/app/design/frontend/Diana/default-theme/Magento_Customer/templates/collapsible-override.phtml
+++ b/app/design/frontend/Diana/default-theme/Magento_Customer/templates/collapsible-override.phtml
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+?>
+
+<div class="block <?= $block->escapeHtmlAttr($block->getBlockCss()) ?>">
+    <div class="title <?= $block->escapeHtmlAttr($block->getBlockCss()) ?>-title"
+         data-mage-init='{"toggleAdvanced": {"toggleContainers": "#<?= $block->escapeHtmlAttr($block->getBlockCss()) ?>", "selectorsToggleClass": "active"}}'>
+        <strong>
+            <?= $block->escapeHtml(__($block->getBlockTitle())) ?>
+        </strong>
+    </div>
+    <div class="content <?= $block->escapeHtmlAttr($block->getBlockCss()) ?>-content"
+         id="<?= $block->escapeHtmlAttr($block->getBlockCss()) ?>">
+        <?= $block->getChildHtml() ?>
+        <?= $block->escapeHtml(__('The template was overridden.')) ?>
+    </div>
+</div>

--- a/app/design/frontend/Diana/default-theme/Magento_Search/layout/default.xml
+++ b/app/design/frontend/Diana/default-theme/Magento_Search/layout/default.xml
@@ -7,7 +7,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-<!--        <referenceBlock name="customer_account_navigation" remove="true" />-->
-        <referenceBlock name="sidebar.main.account_nav" template="Magento_Customer::collapsible-override.phtml"/>
+        <referenceBlock name="top.search" template="Magento_Search::magento-search/search/form.mini-override.phtml" />
     </body>
 </page>

--- a/app/design/frontend/Diana/default-theme/Magento_Search/templates/magento-search/search/form.mini-override.phtml
+++ b/app/design/frontend/Diana/default-theme/Magento_Search/templates/magento-search/search/form.mini-override.phtml
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+?>
+<?php
+/** @var $block \Magento\Framework\View\Element\Template */
+/** @var $helper \Magento\Search\Helper\Data */
+/** @var $configProvider \Magento\Search\ViewModel\ConfigProvider */
+$helper = $this->helper(\Magento\Search\Helper\Data::class);
+$configProvider = $block->getData('configProvider');
+?>
+<div class="block block-search">
+    <div class="block block-title"><strong><?= $block->escapeHtml(__('Search')) ?></strong></div>
+    <div class="block block-content">
+        <form class="form minisearch" id="search_mini_form"
+              action="<?= $block->escapeUrl($helper->getResultUrl()) ?>" method="get">
+            <div class="field search">
+                <label class="label" for="search" data-role="minisearch-label">
+                    <span><?= $block->escapeHtml(__('Search')) ?></span>
+                </label>
+                <div class="control"
+                     title= <?= $block->escapeHtmlAttr(__("Extended through theme")) ?>>
+                    <input id="search"
+                        <?php if ($configProvider->isSuggestionsAllowed()):?>
+                            data-mage-init='{"quickSearch":{
+                                    "formSelector":"#search_mini_form",
+                                    "url":"<?= $block->escapeUrl($helper->getSuggestUrl())?>",
+                                    "destinationSelector":"#search_autocomplete",
+                                    "minSearchLength":"<?= $block->escapeHtml($helper->getMinQueryLength()) ?>"}
+                               }'
+                        <?php endif;?>
+                           type="text"
+                           name="<?= $block->escapeHtmlAttr($helper->getQueryParamName()) ?>"
+                           value="<?= /* @noEscape */ $helper->getEscapedQueryText() ?>"
+                           placeholder="<?= $block->escapeHtmlAttr(__('Search entire super-store here...')) ?>"
+                           class="input-text"
+                           maxlength="<?= $block->escapeHtmlAttr($helper->getMaxQueryLength()) ?>"
+                           role="combobox"
+                           aria-haspopup="false"
+                           aria-autocomplete="both"
+                           autocomplete="off"
+                           aria-expanded="false"/>
+                    <div id="search_autocomplete" class="search-autocomplete"></div>
+                    <?= $block->getChildHtml() ?>
+                </div>
+            </div>
+            <div class="actions">
+                <button type="submit"
+                        title="<?= $block->escapeHtmlAttr(__('Search')) ?>"
+                        class="action search"
+                        aria-label="Search"
+                >
+                    <span><?= $block->escapeHtml(__('Search')) ?></span>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>


### PR DESCRIPTION
Override the template of the user navigation block through the theme and add the text "The template was overridden." below the navigation links. Override the search template through a module and change the placeholder "Search entire store here..." within the search-input into "Search entire super-store here...". Extend the template which has been overwritten in the module through the theme directory and add an attribute title "Extended through theme" to the search-input.