### PR TITLE
MAG-25: Initialize UI component through XML

### DIFF
--- a/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
@@ -42,6 +42,9 @@
                         <item name="components" xsi:type="array">
                             <item name="uiComponentMag25" xsi:type="array">
                                 <item name="component" xsi:type="string">js/js-ui-component-mag-25</item>
+                                <item name="config" xsi:type="array">
+                                    <item name="template" xsi:type="string">Magento_Cms/js-ui-component-mag-25</item>
+                                </item>
                             </item>
                         </item>
                     </argument>

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
@@ -35,6 +35,18 @@
             <block name="block.mag.16" class="Magento\Customer\Block\Account\Customer" template="Magento_Cms::template-mag-16.phtml" />
 
             <block name="block.mag.47" template="Magento_Cms::template-mag-47.phtml" />
+
+            <block name="block.mag.25" template="Magento_Cms::template-mag-25.phtml">
+                <arguments>
+                    <argument name="jsLayout" xsi:type="array">
+                        <item name="components" xsi:type="array">
+                            <item name="uiComponentMag25" xsi:type="array">
+                                <item name="component" xsi:type="string">js/js-ui-component-mag-25</item>
+                            </item>
+                        </item>
+                    </argument>
+                </arguments>
+            </block>
         </referenceContainer>
 
         <move element="block.four" destination="container.three" after="block.one" before="block.two" />

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/templates/template-mag-25.phtml
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/templates/template-mag-25.phtml
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/** @var \Magento\Framework\View\Element\Template $block */
+?>
+
+<div data-bind="scope: 'uiComponentMag25' ">
+    <!-- ko template: getTemplate() --><!-- /ko -->
+    <script type="text/x-magento-init">
+            {
+                "*": {
+                    "Magento_Ui/js/core/app": <?= /* @noEscape */ $block->getJsLayout() ?>
+                }
+            }
+    </script>
+</div>

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/web/template/js-ui-component-mag-25.html
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/web/template/js-ui-component-mag-25.html
@@ -1,0 +1,1 @@
+<p>UI component template</p>

--- a/app/design/frontend/Diana/default-theme/web/js/js-ui-component-mag-25.js
+++ b/app/design/frontend/Diana/default-theme/web/js/js-ui-component-mag-25.js
@@ -3,10 +3,6 @@ define([
     'ko'
     ], function(Component, ko) {
     return Component.extend({
-        defaults: {
-            template: 'Magento_Cms/js-ui-component-mag-25'
-        },
-
         /**
          * Init
          */

--- a/app/design/frontend/Diana/default-theme/web/js/js-ui-component-mag-25.js
+++ b/app/design/frontend/Diana/default-theme/web/js/js-ui-component-mag-25.js
@@ -1,0 +1,19 @@
+define([
+    'uiComponent',
+    'ko'
+    ], function(Component, ko) {
+    return Component.extend({
+        defaults: {
+            template: 'Magento_Cms/js-ui-component-mag-25'
+        },
+
+        /**
+         * Init
+         */
+        initialize: function() {
+            this._super();
+
+            console.log('js-ui-component-mag-25');
+        }
+    });
+});


### PR DESCRIPTION
Description
Apply template for the UI component that you have created in one of your previous tickets do it through the JS

Create an XML block and initialize UI component in its PHTML

Render UI component template on the storefront

For this ticket at first merge the MAG-48 brunch into your current