### PR TITLE
MAG-27: Extend template for UI component

### DIFF
--- a/app/design/frontend/Diana/default-theme/Magento_Checkout/web/template/minicart/content.html
+++ b/app/design/frontend/Diana/default-theme/Magento_Checkout/web/template/minicart/content.html
@@ -1,0 +1,104 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<div class="block-title">
+    <strong>
+        <span class="text" translate="'My Cart'"/>
+        <span
+            class="qty empty"
+            text="getCartParam('summary_count')"
+            data-bind="css: { empty: !!getCartParam('summary_count') == false },
+                       attr: { title: $t('Items in Cart') }">
+        </span>
+    </strong>
+</div>
+
+<div class="block-content">
+    <button type="button"
+            id="btn-minicart-close"
+            class="action close"
+            data-action="close"
+            data-bind="attr: { title: $t('Close') }">
+        <span translate="'Close'"/>
+    </button>
+
+    <if args="getCartParam('summary_count')">
+        <div class="items-total">
+            <span class="count" if="maxItemsToDisplay < getCartLineItemsCount()" text="maxItemsToDisplay"/>
+            <translate args="'of'" if="maxItemsToDisplay < getCartLineItemsCount()"/>
+            <span class="count" text="getCartParam('summary_count')"/>
+            <!-- ko if: (getCartLineItemsCount() === 1) -->
+            <span translate="'Item in Cart'"/>
+            <!--/ko-->
+            <!-- ko if: (getCartLineItemsCount() > 1) -->
+            <span translate="'Items in Cart'"/>
+            <!--/ko-->
+        </div>
+
+        <each args="getRegion('subtotalContainer')" render=""/>
+        <each args="getRegion('extraInfo')" render=""/>
+
+        <div class="actions" if="getCartParam('possible_onepage_checkout')">
+            <div class="primary">
+                <button
+                    id="top-cart-btn-checkout"
+                    type="button"
+                    class="action primary checkout"
+                    data-action="close"
+                    data-bind="
+                            attr: {
+                                title: $t('Proceed to Checkout')
+                            },
+                            click: closeMinicart()
+                        "
+                    translate="'Proceed to Checkout'"
+                />
+                <div data-bind="html: getCartParam('extra_actions')"></div>
+            </div>
+        </div>
+    </if>
+
+    <if args="getCartParam('summary_count')">
+        <strong class="subtitle" translate="'Recently added item(s)'"/>
+        <div data-action="scroll" class="minicart-items-wrapper">
+            <ol id="mini-cart" class="minicart-items" data-bind="foreach: { data: getCartItems(), as: 'item' }">
+                <each args="$parent.getRegion($parent.getItemRenderer(item.product_type))"
+                      render="{name: getTemplate(), data: item, afterRender: function() {$parents[1].initSidebar()}}"
+                />
+            </ol>
+        </div>
+    </if>
+
+    <ifnot args="getCartParam('summary_count')">
+        <strong class="subtitle empty"
+                data-bind="visible: closeSidebar()"
+                translate="'You have no items in your shopping cart.'"
+        />
+        <if args="getCartParam('cart_empty_message')">
+            <p class="minicart empty text" text="getCartParam('cart_empty_message')"/>
+            <div class="actions">
+                <div class="secondary">
+                    <a class="action viewcart" data-bind="attr: {href: shoppingCartUrl}">
+                        <span translate="'View and Edit Cart'"/>
+                    </a>
+                </div>
+            </div>
+        </if>
+    </ifnot>
+
+    <div class="actions" if="getCartParam('summary_count')">
+        <div class="secondary">
+            <a class="action viewcart" data-bind="attr: {href: shoppingCartUrl}">
+                <span translate="'View and Edit Cart'"/>
+            </a>
+        </div>
+    </div>
+
+    <div id="minicart-widgets" class="minicart-widgets" if="getRegion('promotion').length">
+        <each args="getRegion('promotion')" render=""/>
+    </div>
+</div>
+<each args="getRegion('sign-in-popup')" render=""/>

--- a/app/design/frontend/Diana/default-theme/Magento_Checkout/web/template/minicart/content.html
+++ b/app/design/frontend/Diana/default-theme/Magento_Checkout/web/template/minicart/content.html
@@ -75,7 +75,7 @@
     <ifnot args="getCartParam('summary_count')">
         <strong class="subtitle empty"
                 data-bind="visible: closeSidebar()"
-                translate="'You have no items in your shopping cart.'"
+                translate="'Your shopping cart is empty.'"
         />
         <if args="getCartParam('cart_empty_message')">
             <p class="minicart empty text" text="getCartParam('cart_empty_message')"/>

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
@@ -42,6 +42,9 @@
                         <item name="components" xsi:type="array">
                             <item name="uiComponentMag25" xsi:type="array">
                                 <item name="component" xsi:type="string">js/js-ui-component-mag-25</item>
+                                <item name="config" xsi:type="array">
+                                    <item name="template" xsi:type="string">Magento_Cms/js-ui-component-mag-25</item>
+                                </item>
                             </item>
                         </item>
                     </argument>

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
@@ -35,6 +35,18 @@
             <block name="block.mag.16" class="Magento\Customer\Block\Account\Customer" template="Magento_Cms::template-mag-16.phtml" />
 
             <block name="block.mag.47" template="Magento_Cms::template-mag-47.phtml" />
+
+            <block name="block.mag.25" template="Magento_Cms::template-mag-25.phtml">
+                <arguments>
+                    <argument name="jsLayout" xsi:type="array">
+                        <item name="components" xsi:type="array">
+                            <item name="uiComponentMag25" xsi:type="array">
+                                <item name="component" xsi:type="string">js/js-ui-component-mag-25</item>
+                            </item>
+                        </item>
+                    </argument>
+                </arguments>
+            </block>
         </referenceContainer>
 
         <move element="block.four" destination="container.three" after="block.one" before="block.two" />

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
@@ -50,6 +50,18 @@
                     </argument>
                 </arguments>
             </block>
+
+            <block name="block.mag.26" template="Magento_Cms::template-mag-25.phtml">
+                <arguments>
+                    <argument name="jsLayout" xsi:type="array">
+                        <item name="components" xsi:type="array">
+                            <item name="uiComponentMag25" xsi:type="array">
+                                <item name="component" xsi:type="string">js/js-ui-component-mag-25</item>
+                            </item>
+                        </item>
+                    </argument>
+                </arguments>
+            </block>
         </referenceContainer>
 
         <move element="block.four" destination="container.three" after="block.one" before="block.two" />

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/layout/cms_index_index.xml
@@ -62,6 +62,8 @@
                     </argument>
                 </arguments>
             </block>
+
+            <block name="block.mag.30" template="Magento_Cms::template-mag-30.phtml" />
         </referenceContainer>
 
         <move element="block.four" destination="container.three" after="block.one" before="block.two" />

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/templates/template-mag-25.phtml
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/templates/template-mag-25.phtml
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/** @var \Magento\Framework\View\Element\Template $block */
+?>
+
+<div data-bind="scope: 'uiComponentMag25' ">
+    <!-- ko template: getTemplate() --><!-- /ko -->
+    <script type="text/x-magento-init">
+            {
+                "*": {
+                    "Magento_Ui/js/core/app": <?= /* @noEscape */ $block->getJsLayout() ?>
+                }
+            }
+    </script>
+</div>

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/templates/template-mag-30.phtml
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/templates/template-mag-30.phtml
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/** @var \Magento\Framework\View\Element\Template $block */
+
+$phtmlData = 'Data from phtml.'
+?>
+<script type="text/x-magento-init">
+    {
+        "*": {
+            "js/js-mag-30":{
+                "dataFromPhtml":"<?= /* @noEscape */ $phtmlData; ?>"
+            }
+        }
+    }
+</script>
+

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/web/template/js-ui-component-mag-25.html
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/web/template/js-ui-component-mag-25.html
@@ -1,0 +1,1 @@
+<p>UI component template</p>

--- a/app/design/frontend/Diana/default-theme/Magento_Cms/web/template/js-ui-component-mag-26.html
+++ b/app/design/frontend/Diana/default-theme/Magento_Cms/web/template/js-ui-component-mag-26.html
@@ -1,0 +1,1 @@
+<p>js-ui-component-mag-26.html</p>

--- a/app/design/frontend/Diana/default-theme/web/js/js-mag-30.js
+++ b/app/design/frontend/Diana/default-theme/web/js/js-mag-30.js
@@ -1,0 +1,9 @@
+define([], function() {
+    'use strict';
+
+    return function(config, element) {
+        var data = config.dataFromPhtml;
+        console.log('mag-30');
+        console.log(data);
+    }
+});

--- a/app/design/frontend/Diana/default-theme/web/js/js-ui-component-mag-25.js
+++ b/app/design/frontend/Diana/default-theme/web/js/js-ui-component-mag-25.js
@@ -3,6 +3,11 @@ define([
     'ko'
     ], function(Component, ko) {
     return Component.extend({
+
+        defaults: {
+            template: 'Magento_Cms/js-ui-component-mag-26'
+        },
+
         /**
          * Init
          */

--- a/app/design/frontend/Diana/default-theme/web/js/js-ui-component-mag-25.js
+++ b/app/design/frontend/Diana/default-theme/web/js/js-ui-component-mag-25.js
@@ -3,10 +3,6 @@ define([
     'ko'
     ], function(Component, ko) {
     return Component.extend({
-        defaults: {
-            template: 'Magento_Cms/js-ui-component-mag-25'
-        },
-
         /**
          * Init
          */

--- a/app/design/frontend/Diana/default-theme/web/js/js-ui-component-mag-25.js
+++ b/app/design/frontend/Diana/default-theme/web/js/js-ui-component-mag-25.js
@@ -1,0 +1,19 @@
+define([
+    'uiComponent',
+    'ko'
+    ], function(Component, ko) {
+    return Component.extend({
+        defaults: {
+            template: 'Magento_Cms/js-ui-component-mag-25'
+        },
+
+        /**
+         * Init
+         */
+        initialize: function() {
+            this._super();
+
+            console.log('js-ui-component-mag-25');
+        }
+    });
+});


### PR DESCRIPTION
Description
Extend the template for the UI component
As an example extend minicart template and change “You have no items in your shopping cart.“ for the empty card to “Your shopping cart is empty“