### PR TITLE
MAG-51: Call PHTML file in CMS block or page

### DIFF
--- a/app/design/frontend/Diana/default-theme/Magento_Theme/templates/template-for-cms-page-mag-51.phtml
+++ b/app/design/frontend/Diana/default-theme/Magento_Theme/templates/template-for-cms-page-mag-51.phtml
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+?>
+<p>Some content from the template for the CMS page Homepage.</p>


### PR DESCRIPTION
Description
Create in Magento_Theme module custom phtml template file and add some content there;

Call this PHTML file on the CMS homepage